### PR TITLE
Add 'GitHub Skills' activity (fix missing activity)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <img src="https://octodex.github.com/images/Professortocat_v2.png" align="right" height="200px" />
 
-Hey msimmons1313!
+Hey msimmons1313.
 
 Mona here. I'm done preparing your exercise. Hope you enjoy! 💚
 

--- a/src/app.py
+++ b/src/app.py
@@ -74,6 +74,12 @@ activities = {
         "schedule": "Fridays, 4:00 PM - 5:30 PM",
         "max_participants": 12,
         "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
+    },
+    "GitHub Skills": {
+        "description": "Learn practical coding and collaboration skills with GitHub. First part of our GitHub Certifications program!",
+        "schedule": "Wednesdays, 4:00 PM - 5:00 PM",
+        "max_participants": 25,
+        "participants": []
     }
 }
 


### PR DESCRIPTION
Merging the fix that adds the 'GitHub Skills' activity to the in-memory activities list. This resolves the time-sensitive missing activity reported in issue #6.